### PR TITLE
Add Perm command and add question and solution env

### DIFF
--- a/template.tex
+++ b/template.tex
@@ -152,7 +152,7 @@
 \newcommand{\nullspace}[1]{\mathcal{N}\left(\symbf{#1}\right)}
 \newcommand{\leftnullspace}[1]{\mathcal{N}\left(\symbf{#1}^{\top}\right)}
 
-\newcommand{\Perm}[2]{\prescript{#1}{}{\mathup{P}}_{#2}}
+\newcommand{\Perm}[2]{\prescript{#1}{}{P}_{#2}}
 
 %% Integral Transforms
 

--- a/template.tex
+++ b/template.tex
@@ -62,7 +62,7 @@
 \setmathfont{Latin Modern Math}
 \setmathfont[range={bb, bbit}, Scale=MatchUppercase]{TeX Gyre Pagella Math}
 \setmathfont[range={\mathcal, \mathbfcal}, StylisticSet=1]{XITS Math}
-\setmathfont[range={"2205}]{XITS Math}
+\setmathfont[range={"2205}]{XITS Math} % chktex 18
 
 % Preamble 
 
@@ -79,7 +79,7 @@
 %%% Empty set character
 \let\oldemptyset\emptyset
 \let\varnothing\relax
-\newcommand{\varnothing}{\char"2205}
+\newcommand{\varnothing}{\char"2205} % chktex 18
 
 %%% Contradiction
 \newcommand{\contradiction}{
@@ -152,15 +152,17 @@
 \newcommand{\nullspace}[1]{\mathcal{N}\left(\symbf{#1}\right)}
 \newcommand{\leftnullspace}[1]{\mathcal{N}\left(\symbf{#1}^{\top}\right)}
 
+\newcommand{\Perm}[2]{\prescript{#1}{}{\mathup{P}}_{#2}}
+
 %% Integral Transforms
 
 %%% Laplace Transform
-\newcommand{\laplace}[1]{\char"2112 \left\{{#1}\right\}}
-\newcommand{\invlaplace}[1]{\char"2112^{-1} \left\{{#1}\right\}}
+\newcommand{\laplace}[1]{\char"2112 \left\{{#1}\right\}} % chktex 18
+\newcommand{\invlaplace}[1]{\char"2112^{-1} \left\{{#1}\right\}} % chktex 18
 
 %%% Fourier Transform
-\newcommand{\fourier}[1]{\char"2131 \left\{{#1}\right\}}
-\newcommand{\invfourier}[1]{\char"2131^{-1} \left\{{#1}\right\}}
+\newcommand{\fourier}[1]{\char"2131 \left\{{#1}\right\}} % chktex 18
+\newcommand{\invfourier}[1]{\char"2131^{-1} \left\{{#1}\right\}} % chktex 18
 
 % Theorems
 \theoremstyle{definition}
@@ -177,8 +179,10 @@
 \newtheorem{note}{Note}[subsection]
 \newtheorem*{statement}{Statement}
 
-\newenvironment{solution}[1][Solution]{\proof[#1]\mbox{}\\*}{\endproof}
-\newenvironment{solutionF}[1][Solution]{\proof[#1]\mbox{}}{\endproof}
+\newenvironment{examples}[1][Examples]{\let\qed\relax\proof[#1]\mbox{}\\*}{\endproof}
+\newenvironment{question}[1][Question]{\let\qed\relax\proof[#1]\mbox{}\\*}{\endproof}
+\newenvironment{solution}[1][Solution]{\let\qed\relax\proof[#1]\mbox{}\\*}{\endproof}
+\newenvironment{solutionF}[1][Solution]{\let\qed\relax\proof[#1]\mbox{}}{\endproof}
 
 \newenvironment{proofcase}[1]{\proof[Case #1]\mbox{}}{\endproof}
 


### PR DESCRIPTION
- Adds `\Perm{n}{k}` command for nPk
- Add examples and question environments to match solution environment
- Removes QED from question and solution environments
- Silences warnings from chktex now that we're using a .tex file